### PR TITLE
Fix Typehinting for create_token

### DIFF
--- a/ekranoplan/tokens.py
+++ b/ekranoplan/tokens.py
@@ -8,7 +8,7 @@ from .database import User
 from .errors import Forbidden, Unauthorized
 
 
-def create_token(user_id: Union[int, str], user_password: str):
+def create_token(user_id: int, user_password: str) -> str:
     signer = itsdangerous.TimestampSigner(user_password)
     user_id = str(user_id)
     user_id = base64.b64encode(user_id.encode())


### PR DESCRIPTION
user.id is an int attribute of an user object passed in to create_token
user.id is defined as factory().formulate() , which return type is typehinted as int

I hope that made sense 🗿